### PR TITLE
Add a coverage test using the sample text files in gflanguages

### DIFF
--- a/tests/testcoverage.py
+++ b/tests/testcoverage.py
@@ -49,6 +49,9 @@ def test_coverage():
         # Get Unicode name for script
         if script not in NAMES:
             continue
+        if NAMES[script] == "Hani":
+            # Too generic, pass
+            continue
         namefile = NAMES[script].lower().replace(" ", "-").replace("_", "-")
         cps_in_subset = codepoints_and_optionally_ext(namefile)
         if not cps_in_subset:

--- a/tests/testcoverage.py
+++ b/tests/testcoverage.py
@@ -84,7 +84,9 @@ def test_coverage():
 @pytest.mark.parametrize("namfile", glob.glob("GF_glyphsets/*/nam/*.nam"))
 def test_gf_coverage(namfile):
     """Ensure everything in the GF glyphsets are enabled in subsets"""
-    if "Arabic" in namfile:
+    if "Latin" in namfile or "Phonetics" in namfile:
+        subsets = ["latin"]
+    elif "Arabic" in namfile:
         subsets = ["arabic"]
     elif "Cyrillic" in namfile:
         subsets = ["cyrillic"]
@@ -96,8 +98,6 @@ def test_gf_coverage(namfile):
         subsets = ["greek", "symbols"]
     elif "Greek" in namfile:
         subsets = ["greek"]
-    elif "Latin" in namfile or "Phonetics" in namfile:
-        subsets = ["latin"]
     else:
         assert False, "Don't know what subset to apply for %s" % namfile
     designed_cps = ReadNameList(namfile)["charset"]

--- a/tests/testcoverage.py
+++ b/tests/testcoverage.py
@@ -84,10 +84,10 @@ def test_coverage():
 @pytest.mark.parametrize("namfile", glob.glob("GF_glyphsets/*/nam/*.nam"))
 def test_gf_coverage(namfile):
     """Ensure everything in the GF glyphsets are enabled in subsets"""
-    if "Latin" in namfile or "Phonetics" in namfile:
-        subsets = ["latin"]
-    elif "Vietnamese" in namfile:
+    if "Vietnamese" in namfile:
         subsets = ["vietnamese"]
+    elif "Latin" in namfile or "Phonetics" in namfile:
+        subsets = ["latin"]
     elif "Arabic" in namfile:
         subsets = ["arabic"]
     elif "Cyrillic" in namfile:

--- a/tests/testcoverage.py
+++ b/tests/testcoverage.py
@@ -1,9 +1,16 @@
-from glyphsets.codepoints import CodepointsInSubset
+from glyphsets.codepoints import (
+    CodepointsInSubset,
+    CodepointFileForSubset,
+    ReadNameList,
+    nam_dir,
+)
 from fontTools.unicodedata.Scripts import NAMES
 import pytest
 import unicodedata
 from collections import defaultdict
+import glob
 import warnings
+import os
 import sys
 
 try:
@@ -15,6 +22,15 @@ except Exception as e:
     )
 
 MAGIC_CODEPOINTS = set([0x2010, 0xA])
+
+
+def codepoints_and_optionally_ext(subset):
+    cps_in_subset = CodepointsInSubset(subset, unique_glyphs=False)
+    ext_file = os.path.join(nam_dir, "%s-ext_unique-glyphs.nam" % subset)
+    if os.path.isfile(ext_file):
+        cps_in_subset |= CodepointsInSubset(subset + "-ext")
+    cps_in_subset |= MAGIC_CODEPOINTS
+    return cps_in_subset
 
 
 def test_coverage():
@@ -34,8 +50,7 @@ def test_coverage():
         if script not in NAMES:
             continue
         namefile = NAMES[script].lower().replace(" ", "-").replace("_", "-")
-        cps_in_subset = CodepointsInSubset(namefile, unique_glyphs=False)
-        cps_in_subset |= MAGIC_CODEPOINTS
+        cps_in_subset = codepoints_and_optionally_ext(namefile)
         if not cps_in_subset:
             warnings.warn(f"No codepoints for {langname}")
             failed = True

--- a/tests/testcoverage.py
+++ b/tests/testcoverage.py
@@ -1,0 +1,63 @@
+from glyphsets.codepoints import CodepointsInSubset
+from fontTools.unicodedata.Scripts import NAMES
+import pytest
+import unicodedata
+from collections import defaultdict
+import warnings
+import sys
+
+try:
+    import gflanguages
+except Exception as e:
+    pytest.skip(
+        "Coverage test requires gflanguages to be installed",
+        allow_module_level=True,
+    )
+
+MAGIC_CODEPOINTS = set([0x2010, 0xA])
+
+
+def test_coverage():
+    langs = gflanguages.LoadLanguages()
+    missing = defaultdict(set)
+    bad_langs = defaultdict(list)
+    failed = False
+    for langname, metadata in langs.items():
+        cps_used_in_sample = set()
+
+        for _, sample in metadata.sample_text.ListFields():
+            for cp in sample:
+                cps_used_in_sample.add(ord(cp))
+
+        lang, script = langname.split("_")
+        # Get Unicode name for script
+        if script not in NAMES:
+            continue
+        namefile = NAMES[script].lower().replace(" ", "-").replace("_", "-")
+        cps_in_subset = CodepointsInSubset(namefile, unique_glyphs=False)
+        cps_in_subset |= MAGIC_CODEPOINTS
+        if not cps_in_subset:
+            warnings.warn(f"No codepoints for {langname}")
+            failed = True
+        cps_in_subset = set(cps_in_subset)
+        cps_not_available = cps_used_in_sample - cps_in_subset
+        if cps_not_available:
+            failed = True
+            missing[namefile] |= cps_not_available
+            bad_langs[namefile].append(langname)
+
+    if not failed:
+        return
+
+    for namefile, missing_cps in missing.items():
+
+        print(
+            f"\n{namefile} missing the following codepoints to render samples "
+            f"in {', '.join(bad_langs[namefile])}:\n",
+            file=sys.stderr,
+        )
+        for x in missing_cps:
+            print(
+                "0x%04X  %s %s" % (x, chr(x), unicodedata.name(chr(x))), file=sys.stderr
+            )
+    assert False, "Coverage test failed"

--- a/tests/testcoverage.py
+++ b/tests/testcoverage.py
@@ -86,6 +86,8 @@ def test_gf_coverage(namfile):
     """Ensure everything in the GF glyphsets are enabled in subsets"""
     if "Latin" in namfile or "Phonetics" in namfile:
         subsets = ["latin"]
+    elif "Vietnamese" in namfile:
+        subsets = ["vietnamese"]
     elif "Arabic" in namfile:
         subsets = ["arabic"]
     elif "Cyrillic" in namfile:
@@ -94,7 +96,7 @@ def test_gf_coverage(namfile):
         subsets = ["music"]
     elif "Coptic" in namfile:
         subsets = ["coptic"]
-    elif "Greek_Archaic" in namfile:
+    elif "Greek_Archaic" in namfile or "Greek_Pro" in namfile:
         subsets = ["greek", "symbols"]
     elif "Greek" in namfile:
         subsets = ["greek"]

--- a/tests/testcoverage.py
+++ b/tests/testcoverage.py
@@ -49,7 +49,7 @@ def test_coverage():
         # Get Unicode name for script
         if script not in NAMES:
             continue
-        if NAMES[script] == "Hani":
+        if script == "Hani":
             # Too generic, pass
             continue
         namefile = NAMES[script].lower().replace(" ", "-").replace("_", "-")


### PR DESCRIPTION
This adds a test which ensures that the subset nam files contain sufficient characters to render the sample text for each language. Here is the current output from the test:

```
============================= test session starts ==============================
platform darwin -- Python 3.9.14, pytest-7.1.2, pluggy-1.0.0
rootdir: /Users/simon/others-repos/glyphsets
collected 30 items / 29 deselected / 1 selected

tests/testcoverage.py F                                                  [100%]

=================================== FAILURES ===================================
________________________________ test_coverage _________________________________
Traceback (most recent call last):
  File "/Users/simon/others-repos/glyphsets/tests/testcoverage.py", line 81, in test_coverage
    assert False, "Coverage test failed"
AssertionError: Coverage test failed
assert False
----------------------------- Captured stderr call -----------------------------
no cp file for chorasmian found at /chorasmian_unique-glyphs.nam
no cp file for meroitic-cursive found at /meroitic-cursive_unique-glyphs.nam
no cp file for meroitic-hieroglyphs found at /meroitic-hieroglyphs_unique-glyphs.nam
no cp file for katakana found at /katakana_unique-glyphs.nam
no cp file for braille found at /braille_unique-glyphs.nam
no cp file for hiragana found at /hiragana_unique-glyphs.nam

latin missing the following codepoints to render samples in lia_Latn, hna_Latn, sey_Latn, ddn_Latn, khw_Latn, nus_Latn, kdh_Latn, tca_Latn, lob_Latn, ale_Latn, fon_Latn, tem_Latn, gaa_Latn, snn_Latn, ajg_Latn, nnp_Latn, ljp_Latn, csa_Latn, boa_Latn, ig_Latn, xsm_Latn, vep_Latn, bwy_Latn, gkp_Latn, ak_Latn, dip_Latn, idu_Latn, cic_Latn, buc_Latn, fvr_Latn, ada_Latn, emk_Latn, fuc_Latn, man_Latn, gn_Latn, ame_Latn, srr_Latn, bci_Latn, huu_Latn, lut_Latn, sus_Latn, maz_Latn, bvi_Latn, udu_Latn, nv_Latn, kri_Latn, mis_Latn, tbz_Latn, nku_Latn, gjn_Latn, ote_Latn, fuv_Latn, guu_Latn, wwa_Latn, dga_Latn, sja_Latn, amr_Latn, nzi_Latn, dag_Latn, yo_Latn, mos_Latn, bm_Latn, dyu_Latn, jra_Latn, str_Latn, non_Latn, bax_Latn, men_Latn, lns_Latn, sla_Latn, bba_Latn, gem_Latn, kbp_Latn, mor_Latn, vi_Latn, mfq_Latn, tzm_Latn, ee_Latn, ln_Latn:

0x0300  ̀ COMBINING GRAVE ACCENT
0x0301  ́ COMBINING ACUTE ACCENT
0x0302  ̂ COMBINING CIRCUMFLEX ACCENT
0x0303  ̃ COMBINING TILDE
0x0304  ̄ COMBINING MACRON
0x0306  ̆ COMBINING BREVE
0x0308  ̈ COMBINING DIAERESIS
0x0309  ̉ COMBINING HOOK ABOVE
0x030C  ̌ COMBINING CARON
0x030D  ̍ COMBINING VERTICAL LINE ABOVE
0x030E  ̎ COMBINING DOUBLE VERTICAL LINE ABOVE
0x0323  ̣ COMBINING DOT BELOW
0x0325  ̥ COMBINING RING BELOW
0x042C  Ь CYRILLIC CAPITAL LETTER SOFT SIGN
0x0331  ̱ COMBINING MACRON BELOW
0x0332  ̲ COMBINING LOW LINE
0x0338  ̸ COMBINING LONG SOLIDUS OVERLAY
0x044A  ъ CYRILLIC SMALL LETTER HARD SIGN
0x044C  ь CYRILLIC SMALL LETTER SOFT SIGN
0x0251  ɑ LATIN SMALL LETTER ALPHA
0x0452  ђ CYRILLIC SMALL LETTER DJE
0x0253  ɓ LATIN SMALL LETTER B WITH HOOK
0x0254  ɔ LATIN SMALL LETTER OPEN O
0x0256  ɖ LATIN SMALL LETTER D WITH TAIL
0x0257  ɗ LATIN SMALL LETTER D WITH HOOK
0x025B  ɛ LATIN SMALL LETTER OPEN E
0x0263  ɣ LATIN SMALL LETTER GAMMA
0x0268  ɨ LATIN SMALL LETTER I WITH STROKE
0x0269  ɩ LATIN SMALL LETTER IOTA
0x0272  ɲ LATIN SMALL LETTER N WITH LEFT HOOK
0x037B  ͻ GREEK SMALL REVERSED LUNATE SIGMA SYMBOL
0x027D  ɽ LATIN SMALL LETTER R WITH TAIL
0x0281  ʁ LATIN LETTER SMALL CAPITAL INVERTED R
0x2081  ₁ SUBSCRIPT ONE
0x2082  ₂ SUBSCRIPT TWO
0x2083  ₃ SUBSCRIPT THREE
0x028A  ʊ LATIN SMALL LETTER UPSILON
0x028B  ʋ LATIN SMALL LETTER V WITH HOOK
0x028C  ʌ LATIN SMALL LETTER TURNED V
0x0294  ʔ LATIN LETTER GLOTTAL STOP
0x1EA1  ạ LATIN SMALL LETTER A WITH DOT BELOW
0x1EA3  ả LATIN SMALL LETTER A WITH HOOK ABOVE
0x1EA5  ấ LATIN SMALL LETTER A WITH CIRCUMFLEX AND ACUTE
0x1EA7  ầ LATIN SMALL LETTER A WITH CIRCUMFLEX AND GRAVE
0x1EA9  ẩ LATIN SMALL LETTER A WITH CIRCUMFLEX AND HOOK ABOVE
0x1EAD  ậ LATIN SMALL LETTER A WITH CIRCUMFLEX AND DOT BELOW
0x02B0  ʰ MODIFIER LETTER SMALL H
0x1EB1  ằ LATIN SMALL LETTER A WITH BREVE AND GRAVE
0x1EB3  ẳ LATIN SMALL LETTER A WITH BREVE AND HOOK ABOVE
0x02B7  ʷ MODIFIER LETTER SMALL W
0x1EB8  Ẹ LATIN CAPITAL LETTER E WITH DOT BELOW
0x1EB9  ẹ LATIN SMALL LETTER E WITH DOT BELOW
0x1DBB  ᶻ MODIFIER LETTER SMALL Z
0x1EBC  Ẽ LATIN CAPITAL LETTER E WITH TILDE
0x1EBD  ẽ LATIN SMALL LETTER E WITH TILDE
0x02BF  ʿ MODIFIER LETTER LEFT HALF RING
0x1EBF  ế LATIN SMALL LETTER E WITH CIRCUMFLEX AND ACUTE
0x1EC1  ề LATIN SMALL LETTER E WITH CIRCUMFLEX AND GRAVE
0x1EC3  ể LATIN SMALL LETTER E WITH CIRCUMFLEX AND HOOK ABOVE
0x1EC5  ễ LATIN SMALL LETTER E WITH CIRCUMFLEX AND TILDE
0x1EC7  ệ LATIN SMALL LETTER E WITH CIRCUMFLEX AND DOT BELOW
0x1ECB  ị LATIN SMALL LETTER I WITH DOT BELOW
0x1ECC  Ọ LATIN CAPITAL LETTER O WITH DOT BELOW
0x1ECD  ọ LATIN SMALL LETTER O WITH DOT BELOW
0x1ED1  ố LATIN SMALL LETTER O WITH CIRCUMFLEX AND ACUTE
0x1ED9  ộ LATIN SMALL LETTER O WITH CIRCUMFLEX AND DOT BELOW
0x1EDB  ớ LATIN SMALL LETTER O WITH HORN AND ACUTE
0x1EDD  ờ LATIN SMALL LETTER O WITH HORN AND GRAVE
0x1EDF  ở LATIN SMALL LETTER O WITH HORN AND HOOK ABOVE
0x1EE3  ợ LATIN SMALL LETTER O WITH HORN AND DOT BELOW
0x1EE4  Ụ LATIN CAPITAL LETTER U WITH DOT BELOW
0x1EE5  ụ LATIN SMALL LETTER U WITH DOT BELOW
0x1EE7  ủ LATIN SMALL LETTER U WITH HOOK ABOVE
0x1EE9  ứ LATIN SMALL LETTER U WITH HORN AND ACUTE
0x1EEB  ừ LATIN SMALL LETTER U WITH HORN AND GRAVE
0x1EEF  ữ LATIN SMALL LETTER U WITH HORN AND TILDE
0x1EF1  ự LATIN SMALL LETTER U WITH HORN AND DOT BELOW

oriya missing the following codepoints to render samples in unr_Orya:

0x035A  ͚ COMBINING DOUBLE RING BELOW

takri missing the following codepoints to render samples in sa_Takr:

0x093D  ऽ DEVANAGARI SIGN AVAGRAHA

saurashtra missing the following codepoints to render samples in sa_Saur:

0x0C3D  ఽ TELUGU SIGN AVAGRAHA

chorasmian missing the following codepoints to render samples in aii_Chrs:

0x10FC0  𐿀 CHORASMIAN LETTER AYIN
0x10FC1  𐿁 CHORASMIAN LETTER PE
0x10FC2  𐿂 CHORASMIAN LETTER RESH
0x10FC3  𐿃 CHORASMIAN LETTER SHIN
0x10FC4  𐿄 CHORASMIAN LETTER TAW
0x10FB0  𐾰 CHORASMIAN LETTER ALEPH
0x10FB2  𐾲 CHORASMIAN LETTER BETH
0x10FB3  𐾳 CHORASMIAN LETTER GIMEL
0x10FB4  𐾴 CHORASMIAN LETTER DALETH
0x10FB5  𐾵 CHORASMIAN LETTER HE
0x10FB6  𐾶 CHORASMIAN LETTER WAW
0x10FB8  𐾸 CHORASMIAN LETTER ZAYIN
0x10FB9  𐾹 CHORASMIAN LETTER HETH
0x10FBA  𐾺 CHORASMIAN LETTER YODH
0x10FBB  𐾻 CHORASMIAN LETTER KAPH
0x10FBC  𐾼 CHORASMIAN LETTER LAMEDH
0x10FBD  𐾽 CHORASMIAN LETTER MEM
0x10FBE  𐾾 CHORASMIAN LETTER NUN
0x10FBF  𐾿 CHORASMIAN LETTER SAMEKH

cypriot missing the following codepoints to render samples in grc_Cprt:

0x10100  𐄀 AEGEAN WORD SEPARATOR LINE

avestan missing the following codepoints to render samples in sa_Avst:

0x200F  ‏ RIGHT-TO-LEFT MARK

hebrew missing the following codepoints to render samples in yi_Hebr, zh_Hebr:

0x05A3  ֣ HEBREW ACCENT MUNAH
0x05F0  װ HEBREW LIGATURE YIDDISH DOUBLE VAV
0x05F1  ױ HEBREW LIGATURE YIDDISH VAV YOD
0x05F2  ײ HEBREW LIGATURE YIDDISH DOUBLE YOD
0x0594  ֔ HEBREW ACCENT ZAQEF QATAN
0x059D  ֝ HEBREW ACCENT GERESH MUQDAM
0x05BF  ֿ HEBREW POINT RAFE

arabic missing the following codepoints to render samples in ota_Arab, kk_Arab, uz_Arab, mrw_Arab, min_Arab, ms_Arab, ug_Arab, ky_Arab, ks_Arab, skr_Arab, zlm_Arab:

0x06A0  ڠ ARABIC LETTER AIN WITH THREE DOTS ABOVE
0x06C5  ۅ ARABIC LETTER KIRGHIZ OE
0x06C6  ۆ ARABIC LETTER OE
0x06C7  ۇ ARABIC LETTER U
0x06C8  ۈ ARABIC LETTER YU
0x06CB  ۋ ARABIC LETTER VE
0x06AC  ڬ ARABIC LETTER KAF WITH DOT ABOVE
0x06AD  ڭ ARABIC LETTER NG
0x068B  ڋ ARABIC LETTER DAL WITH DOT BELOW AND SMALL TAH
0x0672  ٲ ARABIC LETTER ALEF WITH WAVY HAMZA ABOVE
0x0674  ٴ ARABIC LETTER HIGH HAMZA
0x06D5  ە ARABIC LETTER AE
0x065B  ٛ ARABIC VOWEL SIGN INVERTED SMALL V ABOVE
0x06BD  ڽ ARABIC LETTER NOON WITH THREE DOTS ABOVE

cyrillic missing the following codepoints to render samples in evn_Cyrl, gld_Cyrl, oaa_Cyrl:

0x0308  ̈ COMBINING DIAERESIS
0x0304  ̄ COMBINING MACRON
0x0306  ̆ COMBINING BREVE

adlam missing the following codepoints to render samples in ff_Adlm, fuf_Adlm:

0x014B  ŋ LATIN SMALL LETTER ENG
0x060C  ، ARABIC COMMA

kaithi missing the following codepoints to render samples in sa_Kthi:

0x2E31  ⸱ WORD SEPARATOR MIDDLE DOT
0x093D  ऽ DEVANAGARI SIGN AVAGRAHA

modi missing the following codepoints to render samples in sa_Modi:

0x093D  ऽ DEVANAGARI SIGN AVAGRAHA

khudawadi missing the following codepoints to render samples in sa_Sind:

0x093D  ऽ DEVANAGARI SIGN AVAGRAHA

old-hungarian missing the following codepoints to render samples in ohu_Hung:

0x205D  ⁝ TRICOLON

bengali missing the following codepoints to render samples in unr_Beng:

0x035A  ͚ COMBINING DOUBLE RING BELOW

syloti-nagri missing the following codepoints to render samples in sa_Sylo:

0x09BD  ঽ BENGALI SIGN AVAGRAHA

braille missing the following codepoints to render samples in en_Brai:

0x2801  ⠁ BRAILLE PATTERN DOTS-1
0x2802  ⠂ BRAILLE PATTERN DOTS-2
0x2803  ⠃ BRAILLE PATTERN DOTS-12
0x2805  ⠅ BRAILLE PATTERN DOTS-13
0x2806  ⠆ BRAILLE PATTERN DOTS-23
0x2807  ⠇ BRAILLE PATTERN DOTS-123
0x2809  ⠉ BRAILLE PATTERN DOTS-14
0x280A  ⠊ BRAILLE PATTERN DOTS-24
0x280B  ⠋ BRAILLE PATTERN DOTS-124
0x280D  ⠍ BRAILLE PATTERN DOTS-134
0x280E  ⠎ BRAILLE PATTERN DOTS-234
0x280F  ⠏ BRAILLE PATTERN DOTS-1234
0x2811  ⠑ BRAILLE PATTERN DOTS-15
0x2813  ⠓ BRAILLE PATTERN DOTS-125
0x2815  ⠕ BRAILLE PATTERN DOTS-135
0x2817  ⠗ BRAILLE PATTERN DOTS-1235
0x2819  ⠙ BRAILLE PATTERN DOTS-145
0x281A  ⠚ BRAILLE PATTERN DOTS-245
0x281B  ⠛ BRAILLE PATTERN DOTS-1245
0x281D  ⠝ BRAILLE PATTERN DOTS-1345
0x281E  ⠞ BRAILLE PATTERN DOTS-2345
0x281F  ⠟ BRAILLE PATTERN DOTS-12345
0x2824  ⠤ BRAILLE PATTERN DOTS-36
0x2825  ⠥ BRAILLE PATTERN DOTS-136
0x2827  ⠧ BRAILLE PATTERN DOTS-1236
0x282D  ⠭ BRAILLE PATTERN DOTS-1346
0x2832  ⠲ BRAILLE PATTERN DOTS-256
0x283A  ⠺ BRAILLE PATTERN DOTS-2456
0x283D  ⠽ BRAILLE PATTERN DOTS-13456

limbu missing the following codepoints to render samples in sa_Limb, lif_Limb:

0x0964  । DEVANAGARI DANDA

lycian missing the following codepoints to render samples in xlc_Lyci:

0x205A  ⁚ TWO DOT PUNCTUATION

multani missing the following codepoints to render samples in sa_Mult:

0x0964  । DEVANAGARI DANDA

dogra missing the following codepoints to render samples in sa_Dogr:

0x093D  ऽ DEVANAGARI SIGN AVAGRAHA

old-turkic missing the following codepoints to render samples in otk_Orkh:

0x205A  ⁚ TWO DOT PUNCTUATION
=========================== short test summary info ============================
FAILED tests/testcoverage.py::test_coverage - AssertionError: Coverage test f...
======================= 1 failed, 29 deselected in 2.68s =======================
```