### PR TITLE
Require unicodedata2 explicitly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ setuptools
 FontTools[ufo]
 glyphsLib
 defcon
+unicodedata2

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,6 @@ setup(
         'FontTools[ufo]',
         'glyphsLib',
         'defcon',
+        'unicodedata2',
     ]
 )


### PR DESCRIPTION
The unicodedata2 package is imported in Lib/glyphsets/__init__.py. While it is implicitly pulled in by FontTools, it is an actual requirement here.

Signed-off-by: Athos Ribeiro <athos.ribeiro@canonical.com>