### PR TITLE
GF_Latin_African: add dieresisbelowcomb

### DIFF
--- a/GF_glyphsets/Latin/glyphs/GF_Latin_African.glyphs
+++ b/GF_glyphsets/Latin/glyphs/GF_Latin_African.glyphs
@@ -4810,6 +4810,16 @@ width = 600;
 unicode = 787;
 },
 {
+glyphname = dieresisbelowcomb;
+layers = (
+{
+layerId = m01;
+width = 300;
+}
+);
+unicode = 804;
+},
+{
 color = 7;
 glyphname = ringbelowcomb;
 lastChange = "2022-03-04 15:36:06 +0000";

--- a/Lib/glyphsets/data.json
+++ b/Lib/glyphsets/data.json
@@ -26692,7 +26692,8 @@
       "character": "\u0324",
       "unicode": 804,
       "glyphsets": [
-        "GF_Phonetics_IPAStandard"
+        "GF_Phonetics_IPAStandard",
+        "GF_Latin_African"
       ]
     },
     {


### PR DESCRIPTION
Fix #119, as Ṳ, ṳ are in GF_Latin_African and dieresisbelowcomb U+0324 is used as a component.

Additionally Ṳ, ṳ or W̤, w̤ are defined in the Gabon Scientific Alphabet and may be used in Gabon languages orthographies (like Fang-Ntumu or Fang-Nzaman in some documents).