### PR TITLE
Update scripts

### DIFF
--- a/scripts/assemble_charactersets.py
+++ b/scripts/assemble_charactersets.py
@@ -109,7 +109,10 @@ def assemble_characterset(languages_yaml_path):
     for _i, unicode in enumerate(sorted(list(character_set))):
         unicode = f"{unicode:#0{6}X}".replace("0X", "")
         glyph_info = _lookup_attributes_by_unicode(unicode, GLYPHDATA)
-        glyph = glyphsLib.GSGlyph(glyph_info["name"])
+        if "name" in glyph_info:
+            glyph = glyphsLib.GSGlyph(glyph_info["name"])
+        else:
+            glyph = glyphsLib.GSGlyph(f"uni{unicode}")
         glyph.unicode = unicode
         font.glyphs.append(glyph)
 

--- a/scripts/assemble_charactersets.py
+++ b/scripts/assemble_charactersets.py
@@ -80,6 +80,9 @@ def assemble_characterset(languages_yaml_path):
         nam_extends_path = str(Path(nam_path).parent / name) + ".nam"
         extends.update(nam_to_chars(nam_extends_path))
 
+    # Ignore or use auxiliary characters, ignore by default
+    use_aux = language_definitions.get("use_auxiliary", False)
+
     # Assemble character sets from gflanguages
     languages = gflanguages.LoadLanguages()
     for language_code in language_definitions["language_codes"]:
@@ -96,7 +99,7 @@ def assemble_characterset(languages_yaml_path):
                     | set(chars.marks)
                     | set(chars.numerals)
                     | set(chars.punctuation)
-                    # | set(chars.auxiliary) # Not to be part of charsets
+                    | (set(chars.auxiliary) if use_aux else set())
                 )
                 if c not in (" ", "{", "}", "◌")
             }

--- a/scripts/assemble_languages.py
+++ b/scripts/assemble_languages.py
@@ -35,6 +35,12 @@ def main(args):
         default=[],
         help="Languages that should be included even if they don’t match the other requirements.",
     )
+    arg_parser.add_argument(
+        "--exclude-languages",
+        nargs="+",
+        default=[],
+        help="Languages that should be excluded even if they match the other requirements.",
+    )
     options = arg_parser.parse_args(args)
     options.population = int(options.population)
 
@@ -62,7 +68,7 @@ def main(args):
             (
                 language_code in options.include_languages
                 or set(languages[language_code].region).intersection(country_codes)
-            )
+            ) and language_code not in options.exclude_languages
             and languages[language_code].population >= options.population
             and languages[language_code].script in options.script
         ):

--- a/scripts/assemble_languages.py
+++ b/scripts/assemble_languages.py
@@ -5,6 +5,7 @@ in Europe or Americas and have more than 5 million speakers.
 
 import argparse
 import gflanguages
+import logging
 
 SPEAKERS = 5000000
 
@@ -55,6 +56,7 @@ def main(args):
     language_codes = set()
 
     # Print languages if they are supported through the logic
+    print("language_codes:")
     for language_code in sorted(languages.keys()):
         if (
             (
@@ -65,8 +67,8 @@ def main(args):
             and languages[language_code].script in options.script
         ):
             if not languages[language_code].exemplar_chars:
-                print(
-                    f"WARNING, {languages[language_code].name} has no character defintions."
+                logging.warning(
+                    f"{languages[language_code].name} has no character definitions."
                 )
             language_codes.add(language_code)
             print(f"  - {language_code}  # {languages[language_code].name}")

--- a/scripts/assemble_languages.py
+++ b/scripts/assemble_languages.py
@@ -14,12 +14,20 @@ def main(args):
         description="Generates a list of language ids based on given requirements."
     )
     arg_parser.add_argument(
-        "--regions", nargs="+", help="Region or region groups where languages are used."
+        "--regions",
+        nargs="+",
+        help="Region or region groups where languages are used.",
+        default=[],
     )
     arg_parser.add_argument(
         "--population", help="Minimum speakers’ population.", default=SPEAKERS
     )
-    arg_parser.add_argument("--script", help="Script of the languages.")
+    arg_parser.add_argument(
+        "--script",
+        nargs="+",
+        required=True,
+        help="Script of the languages.",
+    )
     arg_parser.add_argument(
         "--include-languages",
         nargs="+",
@@ -30,6 +38,8 @@ def main(args):
     options.population = int(options.population)
 
     regions = gflanguages.LoadRegions()
+    if not options.regions:
+        options.regions = [country_code for country_code in regions]
     languages = gflanguages.LoadLanguages()
 
     country_codes = set()
@@ -52,7 +62,7 @@ def main(args):
                 or set(languages[language_code].region).intersection(country_codes)
             )
             and languages[language_code].population >= options.population
-            and languages[language_code].script == options.script
+            and languages[language_code].script in options.script
         ):
             if not languages[language_code].exemplar_chars:
                 print(


### PR DESCRIPTION
assemble_charactersets.py:
- Skip names when not in GlyphData. Some glyphs don’t have a nice name, use uni name instead.
- Skip chars when extending another glyphset. When a list of glyph sets in the `extends` their characters are skipped. For example GF Latin African extends GF Latin Core.

assemble_languages.py:
- Make --regions optional, make --script nargs. Use all regions when none is specified. Allow specifying more than one script.